### PR TITLE
(+semver: feature) Added expanded distinction definitions for Product and Test

### DIFF
--- a/Distinctions/Software Engineering/Common.md
+++ b/Distinctions/Software Engineering/Common.md
@@ -1,0 +1,45 @@
+# Common
+
+## Typical sprint work
+
+We follow two-week sprints with a daily standup. Within the sprint, you will also take part in grooming meetings with any squads you are part of. Sprints end and the next starts on the same day, so once every two weeks we have a sprint retrospective and planning meeting.
+
+### Sprint planning
+
+When starting a sprint, the software engineering team and the product team meet to discuss which stories and bugs will be worked on in the sprint. Because the product team prioritizes the backlog ahead of time, this is a time to review the planned work and evaluate whether the work is appropriate and actionable within the sprint. Most of the stories in the backlog are already groomed at this point, but some may require grooming in order to be included in the sprint. The software engineering team identifies among itself who will work on each story in the sprint, and the team gets started.
+
+### Standup
+
+For those present in the Downtown Los Angeles office, the entire engineering and product teams gather in the engineering nook and share a brief synopsis of what they're working on today and any blockers to that work. The meeting is intended to remain short (under 10 minutes) and keep everyone generally informed on the progress of the sprint. (People working remotely participate via Slack.)
+
+Often a person's report within standup requires further conversation. These conversations happen after standup with only the interested people involved.
+
+### Grooming
+
+"Grooming" is the act of reviewing a story or bug to evaulate the work needing to be done and to ensure that all necessary aspects of the work are considered. The work is estimated on a scale using the Fibonacci sequence that is roughly calibrated along these points:
+
+| Points | Description                                                  |
+| ------ | ------------------------------------------------------------ |
+| 1      | Tiny                                                         |
+| 2      | Small and well-defined; roughly a day's worth of work        |
+| 3      | Medium                                                       |
+| 5      | Large; roughly a week's worth of work                        |
+| 8      | Very large and multifaceted; could be most of a sprint's worth of work |
+| 13     | Too big; probably needs to be split into smaller stories     |
+
+We follow a written set of guidelines when grooming stories to help ensure all aspects of engineering work is considered for each story.
+
+Most grooming happens within a squad that is focused on a particular feature or set of problems. The squad may include other people as subject matter experts as they see fit.
+
+### Sprint retrospective
+
+At the end of a sprint, the software engineering team and the product team meet to discuss two topics pertaining to the sprint: 
+
+- What did we do well?
+- What should we have done better?
+
+Everyone is invited to share. We often call out team and individual achievements like "we completed every goal for this sprint" and "Kevin and Dave handled the investigation of the recurring bug and found a solution to eliminate it." In order to maintain an open and honest retrospective, we work to guard against blame when it comes to answering "What should we have done better?" The conversation is centered around the problems that were encountered and the actions we can take to resolve or avoid those problems. Most retrospectives end with a couple of action items identified for specific people to take. The retrospective notes are recorded in our wiki for anyone to review.
+
+### Code review
+
+We maintain a general standard of requiring two other software engineers to review and approve all code changes. This process is done through pull requests, and typically involves reading through and evaluating the code. Every software engineer is expected to submit pull requests for their work and to review their peers' pull requests as needed. Feedback is focused on the code and the problem being solved. We ask questions and learn from pull requests.

--- a/Distinctions/Software Engineering/Devices.md
+++ b/Distinctions/Software Engineering/Devices.md
@@ -1,0 +1,56 @@
+# Distinction: Software Engineering, Devices
+
+The Devices distinction primarily involves research, design, architecture, and integration of Internet-of-Things and embedded devices. It includes electrical engineering as needed.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+
+### Grooming
+
+TBD
+
+### Story work
+
+TBD
+
+### Code review
+
+TBD
+
+## Areas of growth
+
+* TBD
+* TBD
+* TBD
+
+## Examples of challenges
+
+* TBD
+* TBD
+* TBD
+* TBD
+* TBD
+
+## Significant contributions
+
+### Within the team
+
+TBD
+
+### Within the company
+
+TBD
+
+### Within the user base
+
+TBD
+
+### Within the engineering community
+
+TBD
+
+### Within the public
+
+TBD

--- a/Distinctions/Software Engineering/Platform.md
+++ b/Distinctions/Software Engineering/Platform.md
@@ -1,0 +1,56 @@
+# Distinction: Software Engineering, Platform
+
+The Platform distinction primarily involves design, architecture, and implementation of Software-as-a-Service technologies. It includes databases, data structures, algorithms, and microservices.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+
+### Grooming
+
+TBD
+
+### Story work
+
+TBD
+
+### Code review
+
+TBD
+
+## Areas of growth
+
+* TBD
+* TBD
+* TBD
+
+## Examples of challenges
+
+* TBD
+* TBD
+* TBD
+* TBD
+* TBD
+
+## Significant contributions
+
+### Within the team
+
+TBD
+
+### Within the company
+
+TBD
+
+### Within the user base
+
+TBD
+
+### Within the engineering community
+
+TBD
+
+### Within the public
+
+TBD

--- a/Distinctions/Software Engineering/Product.md
+++ b/Distinctions/Software Engineering/Product.md
@@ -1,0 +1,63 @@
+# Distinction: Software Engineering, Product
+
+The Product distinction primarily involves design, architecture, and implemention of user experience, including third-party developer experience. It includes a focus on polish and reliability of the finished product. This distinction is focused on the human-software interactions at all levels of our system.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+
+### Grooming
+
+You will work with the product team to offer technical feedback on user interface and user experience and to work out how to implement the planned product work.
+
+### Story work
+
+You will work with the product team to iterate on user experience. This kind of work is often done either "over the shoulder," done in a shared integration environment, or using a tool like [Storybook](https://storybook.js.org/), [GitBook](https://www.gitbook.com/), [OpenAPI](https://swagger.io/docs/specification/about/), or [API Blueprint](https://apiblueprint.org/).
+
+### Code review
+
+During code reviews, you will also work to ensure the user experience of the product is maintained or improved.
+
+## Areas of growth
+
+* Familiarization, implementation, and development of accessibility, user interface, and user experience design systems, e.g.:
+  * [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/)
+  * [A11y Project](https://a11yproject.com/checklist.html)
+  * [Material System](https://material.io/design/)
+  * [Apple Human Interface Guidelines](https://developer.apple.com/design/)
+* Measuring and improving human experience with our software and processes, e.g.:
+  * Rider experience
+  * Driver, dispatcher, planner (i.e., "customer") experience
+  * Developer experience
+* Stewardship of open source projects and interaction with the open source community
+
+## Examples of challenges
+
+* Displaying hundreds of vehicles on a map that updates in real-time
+* Displaying real-time video from on-vehicle cameras
+* Developing web pages that are resilient to unstable network connections
+* Displaying real-time content on internet-connected signs
+* Integrating software telephony (VOIP) into a web app and an Android app
+
+## Significant contributions
+
+### Within the team
+
+You contribute to your fellow software engineers' experience by working on continually improving developer experience.
+
+### Within the company
+
+Your work is the most visible part of the company's product.
+
+### Within the user base
+
+Your work is the interface drivers use to stay connected to dispatchers, dispatchers use to stay informed of their transit systems, and planners use to inform usage and policy decisions.
+
+### Within the engineering community
+
+You contribute to the maintenance and accessibility of our open source projects.
+
+### Within the public
+
+Your work is an interface by which riders make use of their transit systems.

--- a/Distinctions/Software Engineering/Site Reliability.md
+++ b/Distinctions/Software Engineering/Site Reliability.md
@@ -1,0 +1,56 @@
+# Distinction: Software Engineering, Site Reliability
+
+The Site Reliability distinction primarily involves hosting, reliability, observability, monitoring, and alerting. It includes developer experience, continuous integration/delivery, and tooling.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+
+### Grooming
+
+TBD
+
+### Story work
+
+TBD
+
+### Code review
+
+TBD
+
+## Areas of growth
+
+* TBD
+* TBD
+* TBD
+
+## Examples of challenges
+
+* TBD
+* TBD
+* TBD
+* TBD
+* TBD
+
+## Significant contributions
+
+### Within the team
+
+TBD
+
+### Within the company
+
+TBD
+
+### Within the user base
+
+TBD
+
+### Within the engineering community
+
+TBD
+
+### Within the public
+
+TBD

--- a/Distinctions/Software Engineering/Test.md
+++ b/Distinctions/Software Engineering/Test.md
@@ -1,0 +1,62 @@
+# Distinction: Software Engineering, Test
+
+The Test distinction primarily involves testability, repeatability, quality assurance, and automation. It also includes practices of diagnosis and prevention. This distinction is focused on approaching matters of quality with the mindset and tools of a software engineer.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+### Grooming
+
+You will work with the product team to offer technical feedback on acceptance criteria and test case development. You will help determine key areas to focus testing efforts on, including assessing risk factors associated with proposed changes.
+
+### Story work
+
+You will work with the engineering team to iterate on testing systems and standards, test case management, and test automation.
+
+### Code review
+
+During code reviews, you will also work to assess risk factors in the code and ensure that the code is appropriately covered by tests. (e.g., unit or integration tests, end-to-end tests, or appropriate acceptance criteria.)
+
+### Quality Working Group
+
+(The Quality Working Group is a cross-department, multidisciplinary group of people organized to maintain a high level of quality within the company.)
+
+You will work with the Quality Working Group in the development and maintenance of comprehensive quality guidelines and processes. You will also take part in the review of root cause analyses.
+
+## Areas of growth
+
+- Familiarization, implementation, and development of testing systems and standards
+- Measuring and improving software quality
+- Developing robust systems and processes for testing resilient software intended for mobile and IoT devices
+
+## Examples of challenges
+
+- Measuring test coverage across dozens of applications and services
+- Implementing test case management proceses and systems
+- Implementing automated testing systems
+- Developing automated tests for websites and mobile apps
+- Developing protocols for testing IoT devices
+
+## Significant contributions
+
+
+### Within the team
+
+You contribute to your fellow software engineers' experience by improving the feedback from testing systems. You assess risk in software development practices and identify ways of mitigating that risk.
+
+### Within the company
+
+Your work helps improve our customers' experience of our system and helps our project managers and support staff provide consistently high-quality service.
+
+### Within the user base
+
+You contribute to improving the critical moments when software does not work as intended, whether by directly participating in troubleshooting or in developing systems for mitigating defects.
+
+### Within the engineering community
+
+You contribute to the maintenance and reliability of our open source projects.
+
+### Within the public
+
+Your work is a largely-invisible quality of the system that transit riders interact with.

--- a/Distinctions/System Integration/Reliability and Readiness.md
+++ b/Distinctions/System Integration/Reliability and Readiness.md
@@ -1,0 +1,56 @@
+# Distinction: Software Engineering, Reliability & Readiness
+
+The Reliability & Readiness distinction primarily involves testability, repeatability, and quality assurance. There is an emphasis on ensuring the software and hardware work together in harsh environments. It involves working closely with the Operations team to solve problems as they arise and to provide specific engineering specifications for different vehicles.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+
+### Grooming
+
+TBD
+
+### Story work
+
+TBD
+
+### Code review
+
+TBD
+
+## Areas of growth
+
+* TBD
+* TBD
+* TBD
+
+## Examples of challenges
+
+* TBD
+* TBD
+* TBD
+* TBD
+* TBD
+
+## Significant contributions
+
+### Within the team
+
+TBD
+
+### Within the company
+
+TBD
+
+### Within the user base
+
+TBD
+
+### Within the engineering community
+
+TBD
+
+### Within the public
+
+TBD

--- a/Distinctions/System Integration/Research and Development.md
+++ b/Distinctions/System Integration/Research and Development.md
@@ -1,0 +1,56 @@
+# Distinction: Software Engineering, Research & Development
+
+The Research & Development distinction primarily involves research, design, manufacturing/OEM sourcing, and documentation planning for field rollout. There is a focus on developing hardware solutions for new product features and generating appropriate documentation to accompany them.
+
+## Typical sprint work
+
+In addition to the common [typical sprint work](Common.md#typical-sprint-work), you will practice your distinction a number of ways.
+
+
+### Grooming
+
+TBD
+
+### Story work
+
+TBD
+
+### Code review
+
+TBD
+
+## Areas of growth
+
+* TBD
+* TBD
+* TBD
+
+## Examples of challenges
+
+* TBD
+* TBD
+* TBD
+* TBD
+* TBD
+
+## Significant contributions
+
+### Within the team
+
+TBD
+
+### Within the company
+
+TBD
+
+### Within the user base
+
+TBD
+
+### Within the engineering community
+
+TBD
+
+### Within the public
+
+TBD

--- a/README.md
+++ b/README.md
@@ -34,14 +34,13 @@ We have built this career framework to have two dimensions: Title and Distinctio
 
 ### Titles
 
-| Title | Scope of Influence           | Contributions  | Ownership |
-| ------------- |-------------|------|---|
-| Intern        | Themselves and their tasks. | Completes well-specified tasks while receiving technical mentoring. Striving to learn in a self-directed way. | No ownership responsibility yet: this person is learning and being actively developed by others.
-| Associate      | Themselves and their tasks.      | Works on well-specified tasks in a self-directed manner. Collaborates with team and asks for help when working near the periphery of their knowledge or experience. | No ownership responsibility yet: this person is learning and being actively developed by others.
-| Engineer       | Their project and their peers.    | Breaks down large and complex tasks into manageable tasks. | Co-owns an area with guidance & takes initiative (e.g fixes bugs unprompted)
-| Senior Engineer | Whole team/product area | Translates ideas into projects with discrete tasks and guides and unblocks others on the team. Collaborates with non-technical team members to give technical advice. | Has a consistent record of **very strong ownership** for their area, e.g. figuring out on-call schedules, establishing monitoring
-| Principal Engineer | Multiple teams/projects | Leads architecture of new systems/technologies/processes to improve the business. Communicates complex matters in understandable terms for a wide range of audiences. | Exhibits ownership across the org - this person is a guardian of **GMV Syncromatics**
-
+| Title              | Scope of Influence             | Contributions                                                | Ownership                                                    |
+| ------------------ | ------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Intern             | Themselves and their tasks.    | Completes well-specified tasks while receiving technical mentoring. Striving to learn in a self-directed way. | No ownership responsibility yet: this person is learning and being actively developed by others. |
+| Associate          | Themselves and their tasks.    | Works on well-specified tasks in a self-directed manner. Collaborates with team and asks for help when working near the periphery of their knowledge or experience. | No ownership responsibility yet: this person is learning and being actively developed by others. |
+| Engineer           | Their project and their peers. | Breaks down large and complex tasks into manageable tasks.   | Co-owns an area with guidance & takes initiative (e.g fixes bugs unprompted). |
+| Senior Engineer    | Whole team/product area        | Translates ideas into projects with discrete tasks and guides and unblocks others on the team. Collaborates with non-technical team members to give technical advice. | Has a consistent record of **very strong ownership** for their area, (e.g. figuring out on-call schedules, establishing monitoring). |
+| Principal Engineer | Multiple teams/projects        | Leads architecture of new systems/technologies/processes to improve the business. Communicates complex matters in understandable terms for a wide range of audiences. | Exhibits ownership across the organization (e.g. this person is a guardian of **GMV Syncromatics**) |
 
 ### Distinctions
 
@@ -51,22 +50,22 @@ Distinctions are grouped into "paths" that describe a collection of broadly rela
 
 People in the software engineering path are focused on designing and building software.
 
-| Distinction | Domain expertise |
-| ----------- | ---------------- |
-| Platform | Design, architecture, and implementation of Software-as-a-Service technologies. Includes databases, data structures, algorithms, and microservices. |
-| Product | Design, architecture, and implemention of user experience, including third-party developer experience. Includes focus on polish and reliability of the finished product. |
-| Devices | Research, design, architecture, and integration of Internet-of-Things and embedded devices. Includes electrical engineering as needed. |
-| Site Reliability | Hosting, reliability, observability, monitoring, and alerting. Includes developer experience, continuous integration/delivery, and tooling. |
-| Test | Testability, repeatability, quality assurance, and automation. Includes diagnosis and prevention. |
+| Distinction                                             | Domain expertise                                             |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| [Platform](Distinctions/Software Engineering/Platform.md)                                                | Design, architecture, and implementation of Software-as-a-Service technologies. Includes databases, data structures, algorithms, and microservices. |
+| [Product](Distinctions/Software Engineering/Product.md) | Design, architecture, and implemention of user experience, including third-party developer experience. Includes focus on polish and reliability of the finished product. |
+| [Devices](Distinctions/Software Engineering/Devices.md)                                                 | Research, design, architecture, and integration of Internet-of-Things and embedded devices. Includes electrical engineering as needed. |
+| [Site Reliability](Distinctions/Software Engineering/Site Reliability.md)                                        | Hosting, reliability, observability, monitoring, and alerting. Includes developer experience, continuous integration/delivery, and tooling. |
+| [Test](Distinctions/Software Engineering/Test.md)                                                    | Testability, repeatability, quality assurance, and automation. Includes diagnosis and prevention. |
 
 #### System Integration path
 
 People in the system integration path are focused on integrating software and hardware and certifying its viability and reliability for use in the field.
 
-| Distinction | Domain expertise |
-| ----------- | ---------------- |
-| Reliability & Readiness | Testability, repeatability, and quality assurance. Emphasis on ensuring the software and hardware work together in harsh environments. Works closely with OPS to solve problems as they arise and to provide specific engineering specifications for different vehicles. |
-| Research & Development | Research, design, manufacturing/OEM sourcing, and documentation planning for field rollout. Focus on developing hardware solutions for new product features and generating appropriate documentation to accompany them. |
+| Distinction             | Domain expertise                                             |
+| ----------------------- | ------------------------------------------------------------ |
+| [Reliability & Readiness](Distinctions/System Integration/Reliability and Readiness.md) | Testability, repeatability, and quality assurance. Emphasis on ensuring the software and hardware work together in harsh environments. Works closely with OPS to solve problems as they arise and to provide specific engineering specifications for different vehicles. |
+| [Research & Development](Distinctions/System Integration/Research and Development.md)  | Research, design, manufacturing/OEM sourcing, and documentation planning for field rollout. Focus on developing hardware solutions for new product features and generating appropriate documentation to accompany them. |
 
 ## Evaluating growth and evolution
 


### PR DESCRIPTION
* Added stubs for the rest of the distinctions

Yet-to-be-done:

- [ ] Fill in expanded distinctions for Devices, Platform, Site Reliability, Reliability & Readiness, and Research & Development
- [ ] Get feedback from team on applicability