### PR TITLE
Clarify product management involvement in squads

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We have built this career framework to have two dimensions: Title and Distinctio
 
 Our Engineering department is organized into "Squads". A Squad is an unit of Software Engineering that can independently design and deliver on Product, Platform, Devices or SRE initiatives. The full-stack nature of a squad goes deep and wide. A Squad comprises of 3 - 4 Software Engineers (including a Lead), 1 - 2 QA Engineer(s).
 
-Squads are independent Engineering resources each assigned to one Product Area or Vertical at any point of time, collaborating on technical architecture, best practice, and releases with fair opporunity for internal mobility and vertical growth. As dedicated resources to specific products, squads also include a single Product Manager and contributions from a UX & UI Designer, who may be members of multiple squads.
+Squads are independent Engineering resources each assigned to one Product Area or Vertical at any point of time, collaborating on technical architecture, best practice, and releases with fair opporunity for internal mobility and vertical growth. As dedicated resources to specific products areas, squads also include a single Product Manager and contributions from a UX & UI Designer, who may be members of multiple squads.
 
 ### Titles
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ We have built this career framework to have two dimensions: Title and Distinctio
 
 ## Team Organization
 
-Our Engineering department is organized into "Squads". A Squad is an unit of Software Engineering that can independently design and deliver on Product, Platform, Devices or SRE initiatives. The full-stack nature of a squad goes deep and wide. A Squad comprises of 3 - 4 Software Engineers (including a Lead), 1 - 2 QA Engineer(s). Squads also include a single Product Manager and contributions from a UI & UX Designer, who may be members of multiple squads.
+Our Engineering department is organized into "Squads". A Squad is an unit of Software Engineering that can independently design and deliver on Product, Platform, Devices or SRE initiatives. The full-stack nature of a squad goes deep and wide. A Squad comprises of 3 - 4 Software Engineers (including a Lead), 1 - 2 QA Engineer(s).
 
-Squads are independent Engineering resources each assigned to one Product Area or Vertical at any point of time, collaborating on technical architecture, best practice, and releases with fair opporunity for internal mobility and vertical growth.
+Squads are independent Engineering resources each assigned to one Product Area or Vertical at any point of time, collaborating on technical architecture, best practice, and releases with fair opporunity for internal mobility and vertical growth. As dedicated resources to specific products, squads also include a single Product Manager and contributions from a UX & UI Designer, who may be members of multiple squads.
 
 ### Titles
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We have built this career framework to have two dimensions: Title and Distinctio
 
 ## Team Organization
 
-Our Engineering department is organized into "Squads". A Squad is an unit of Software Engineering that can independently design and deliver on Product, Platform, Devices or SRE initiatives. The full-stack nature of a squad goes deep and wide. A Squad comprises of 3 - 4 Software Engineers (including a Lead), 1 - 2 QA Engineer(s), and a dedicated Product Owner / Manager.
+Our Engineering department is organized into "Squads". A Squad is an unit of Software Engineering that can independently design and deliver on Product, Platform, Devices or SRE initiatives. The full-stack nature of a squad goes deep and wide. A Squad comprises of 3 - 4 Software Engineers (including a Lead), 1 - 2 QA Engineer(s). Squads also include a single Product Manager and contributions from a UI & UX Designer, who may be members of multiple squads.
 
 Squads are independent Engineering resources each assigned to one Product Area or Vertical at any point of time, collaborating on technical architecture, best practice, and releases with fair opporunity for internal mobility and vertical growth.
 


### PR DESCRIPTION
This PR clarifies the role of product team members included in squads.

## Description

Previously, a product team members was listed as "Product Owner / Manager," which was confusing due to the role of Engineering Manager discussed later in the document. It was not clear if the "Product Owner / Manager" referred to a single person who may have two titles (Product Owner and Product Manager) or to two separate people (a Product Owner and a Manager of some type -- presumable Engineering). This has been clarified, and reference to UX & UI Design has been added along with a note that these product team members may be part of more than one squad (assuming our near future in which we divide squads further than current).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.